### PR TITLE
fix: allow view refresh after auto-fill initiation

### DIFF
--- a/ui/src/app/updates/messages/updates/state_management.rs
+++ b/ui/src/app/updates/messages/updates/state_management.rs
@@ -163,8 +163,6 @@ where
                             log::error!("Failed to execute auto-fill: {e}");
                         } else {
                             log::debug!("Auto-fill initiated for incomplete page");
-                            // Auto-fill will trigger another message load, so return early
-                            return None;
                         }
                     }
                     Ok(false) => {


### PR DESCRIPTION
Remove early return that prevented view refresh when auto-fill was initiated during message loading, ensuring messages are properly displayed when queue has fewer messages than page size.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message loading behavior to ensure the app state, current page view, and message details are consistently updated, even when auto-fill is triggered for incomplete pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->