### PR TITLE
fix: standardize authentication method from client_credentials to client_seecret

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -114,13 +114,13 @@ method = "azure_ad"
 [azure_ad]
 # Authentication method:
 # - "device_code": Interactive device code flow (recommended for CLI)
-# - "client_credentials": Service principal with client secret (for automation)
+# - "client_secret": Service principal with client secret (for automation)
 auth_method = "device_code"
 
 # Azure AD Configuration (use environment variables for security)
 # tenant_id = ""       # Set via AZURE_AD__TENANT_ID environment variable
 # client_id = ""       # Set via AZURE_AD__CLIENT_ID environment variable
-# client_secret = ""   # Set via AZURE_AD__CLIENT_SECRET (client_credentials only)
+# client_secret = ""   # Set via AZURE_AD__CLIENT_SECRET (client_secret only)
 #                      # Or use encrypted: AZURE_AD__ENCRYPTED_CLIENT_SECRET + AZURE_AD__ENCRYPTION_SALT
 
 # Azure Resource Information (optional - auto-discovered if not specified)

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -110,7 +110,7 @@ Best for automated scenarios, service accounts, and CI/CD pipelines.
 3. **Configure Quetty**:
    ```toml
    [azure_ad]
-   auth_method = "client_credentials"
+   auth_method = "client_secret"
    tenant_id = "your-tenant-id"
    client_id = "your-app-client-id"
    client_secret = "your-client-secret"
@@ -176,7 +176,7 @@ client_id = "87654321-4321-4321-4321-210987654321"
 
 # Method 2: Client Credentials (Automated)
 # [azure_ad]
-# auth_method = "client_credentials"
+# auth_method = "client_secret"
 # tenant_id = "12345678-1234-1234-1234-123456789012"
 # client_id = "87654321-4321-4321-4321-210987654321"
 # client_secret = "your-client-secret"
@@ -212,7 +212,7 @@ AZURE_AD__SCOPE="..."
 SERVICEBUS__CONNECTION_STRING="..."
 
 # Authentication method selection
-AZURE_AD__AUTH_METHOD="device_code"  # or "client_credentials"
+AZURE_AD__AUTH_METHOD="device_code"  # or "client_secret"
 ```
 
 ## Authentication Best Practices

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -299,7 +299,7 @@ method = "azure_ad"  # or "connection_string"
 
 #### `auth_method`
 - **Type**: String
-- **Options**: `"device_code"`, `"client_credentials"`
+- **Options**: `"device_code"`, `"client_secret"`
 - **Description**: Azure AD authentication flow to use.
 
 #### Device Code Authentication
@@ -313,7 +313,7 @@ client_id = "your-client-id"
 #### Client Credentials Authentication
 ```toml
 [azure_ad]
-auth_method = "client_credentials"
+auth_method = "client_secret"
 tenant_id = "your-tenant-id"
 client_id = "your-client-id"
 client_secret = "your-client-secret"
@@ -571,7 +571,7 @@ queue_stats_cache_ttl_seconds = 120
 method = "azure_ad"
 
 [azure_ad]
-auth_method = "client_credentials"
+auth_method = "client_secret"
 
 [logging]
 level = "info"

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -86,7 +86,7 @@ connection_string = "Endpoint=sb://namespace.servicebus.windows.net/;SharedAcces
 #### Option C: Client Credentials (Service Principal)
 ```toml
 [azure_ad]
-auth_method = "client_credentials"
+auth_method = "client_secret"
 tenant_id = "your-tenant-id"
 client_id = "your-client-id"
 client_secret = "your-client-secret"

--- a/server/src/auth/azure_ad.rs
+++ b/server/src/auth/azure_ad.rs
@@ -115,7 +115,7 @@ impl AzureAdProvider {
     ///
     /// # Returns
     ///
-    /// The authentication method string ("device_code" or "client_credentials")
+    /// The authentication method string ("device_code" or "client_secret")
     pub fn flow_type(&self) -> &str {
         &self.config.auth_method
     }
@@ -477,7 +477,7 @@ impl AuthProvider for AzureAdProvider {
     /// Authenticates using the configured Azure AD authentication flow.
     ///
     /// Automatically selects the appropriate authentication method based on the
-    /// configuration (device_code or client_credentials) and handles the complete
+    /// configuration (device_code or client_secret) and handles the complete
     /// OAuth 2.0 flow including error handling and token retrieval.
     ///
     /// # Returns

--- a/server/src/auth/types.rs
+++ b/server/src/auth/types.rs
@@ -165,7 +165,7 @@ impl ConnectionStringConfig {
 ///
 /// # Required Fields
 ///
-/// - `auth_method` - Must be "device_code" or "client_credentials"
+/// - `auth_method` - Must be "device_code" or "client_secret"
 ///
 /// # Required for Device Code Flow
 ///
@@ -210,7 +210,7 @@ impl ConnectionStringConfig {
 /// use server::auth::types::AzureAdAuthConfig;
 ///
 /// let config = AzureAdAuthConfig {
-///     auth_method: "client_credentials".to_string(),
+///     auth_method: "client_secret".to_string(),
 ///     tenant_id: Some("your-tenant-id".to_string()),
 ///     client_id: Some("your-client-id".to_string()),
 ///     client_secret: Some("your-client-secret".to_string()), // Required
@@ -223,14 +223,14 @@ impl ConnectionStringConfig {
 /// ```
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]
 pub struct AzureAdAuthConfig {
-    /// Authentication method: "device_code" or "client_credentials" (REQUIRED)
+    /// Authentication method: "device_code" or "client_secret" (REQUIRED)
     #[serde(default = "default_auth_method")]
     pub auth_method: String,
     /// Azure AD tenant ID (REQUIRED for all flows)
     pub tenant_id: Option<String>,
     /// Azure AD application (client) ID (REQUIRED for all flows)
     pub client_id: Option<String>,
-    /// Azure AD application client secret (REQUIRED for client_credentials flow)
+    /// Azure AD application client secret (REQUIRED for client_secret flow)
     pub client_secret: Option<String>,
     /// Encrypted client secret (alternative to client_secret)
     pub encrypted_client_secret: Option<String>,

--- a/server/src/service_bus_manager.rs
+++ b/server/src/service_bus_manager.rs
@@ -80,7 +80,7 @@ use crate::utils::env::EnvUtils;
 /// # Authentication Methods
 ///
 /// - `device_code` - Interactive device code flow (default for CLI usage)
-/// - `client_credentials` - Service principal authentication
+/// - `client_secret` - Service principal authentication
 /// - `connection_string` - Direct connection string authentication
 ///
 /// # Examples
@@ -100,14 +100,14 @@ use crate::utils::env::EnvUtils;
 /// ```
 #[derive(Clone, Debug, serde::Deserialize, Default)]
 pub struct AzureAdConfig {
-    /// Authentication method: "device_code", "client_credentials", or "connection_string"
+    /// Authentication method: "device_code", "client_secret", or "connection_string"
     #[serde(default = "default_auth_method")]
     pub auth_method: String,
     /// Azure AD tenant ID
     pub tenant_id: Option<String>,
     /// Azure AD application (client) ID
     pub client_id: Option<String>,
-    /// Azure AD application client secret (required for client_credentials)
+    /// Azure AD application client secret (required for client_secret)
     pub client_secret: Option<String>,
     /// Azure subscription ID for resource discovery
     pub subscription_id: Option<String>,


### PR DESCRIPTION
Updates configuration files, documentation, and code comments to use consistent auth_method value of "client_secret" instead of "client_credentials". This resolves authentication configuration mismatches.

Solving #4 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated all documentation and example configuration files to use "client_secret" instead of "client_credentials" as the Azure AD authentication method identifier.
  * Adjusted comments and examples across configuration and authentication documentation for consistency with the new terminology.
  * No changes were made to actual configuration options, logic, or authentication flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->