### PR TITLE
feat: add automated crates.io publishing on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Update version in Cargo.toml files
         shell: bash
         run: |
-          # Update version in both workspace packages using tag version
+          # Update version in workspace using tag version
           # Use portable approach that works across different platforms
 
           # Check if cargo-edit is available for best compatibility
@@ -89,15 +89,13 @@ jobs:
             echo "Using cargo set-version for cross-platform compatibility"
             cargo set-version --workspace "${{ env.VERSION }}"
           else
-            echo "Using awk for cross-platform sed replacement"
+            echo "Using awk for workspace version update"
             # Use awk for better cross-platform compatibility than sed -i
-            awk -v version="${{ env.VERSION }}" 'NR==3{sub(/^version = ".*"/, "version = \"" version "\"")} 1' ui/Cargo.toml > ui/Cargo.toml.tmp && mv ui/Cargo.toml.tmp ui/Cargo.toml
-            awk -v version="${{ env.VERSION }}" 'NR==3{sub(/^version = ".*"/, "version = \"" version "\"")} 1' server/Cargo.toml > server/Cargo.toml.tmp && mv server/Cargo.toml.tmp server/Cargo.toml
+            awk -v version="${{ env.VERSION }}" '/^\[workspace\.package\]/{flag=1; print; next} flag && /^version = /{sub(/version = ".*"/, "version = \"" version "\""); flag=0} 1' Cargo.toml > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
           fi
 
-          echo "Updated versions to: ${{ env.VERSION }}"
-          echo "UI version: $(grep '^version' ui/Cargo.toml)"
-          echo "Server version: $(grep '^version' server/Cargo.toml)"
+          echo "Updated workspace version to: ${{ env.VERSION }}"
+          echo "Workspace version: $(grep -A 10 '^\[workspace\.package\]' Cargo.toml | grep '^version' | cut -d'\"' -f2)"
 
       - name: Build release binary
         run: |
@@ -163,8 +161,121 @@ jobs:
           path: dist/*.${{ matrix.archive_ext }}*
           retention-days: 90
 
-  create-release:
+  publish-to-crates-io:
     needs: build
+    runs-on: ubuntu-latest
+    if: github.ref_type == 'tag' && !contains(github.ref_name, 'rc') && !contains(github.ref_name, 'beta') && !contains(github.ref_name, 'alpha')
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract version from tag
+        run: |
+          VERSION=${GITHUB_REF_NAME#v}
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "Publishing release version: $VERSION"
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      - name: Cache Cargo dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ubuntu-latest-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ubuntu-latest-cargo-
+
+      - name: Update version in Cargo.toml files
+        run: |
+          # Update version in workspace using tag version
+          if command -v cargo-set-version >/dev/null 2>&1; then
+            echo "Using cargo set-version for cross-platform compatibility"
+            cargo set-version --workspace "${{ env.VERSION }}"
+          else
+            echo "Using awk for workspace version update"
+            awk -v version="${{ env.VERSION }}" '/^\[workspace\.package\]/{flag=1; print; next} flag && /^version = /{sub(/version = ".*"/, "version = \"" version "\""); flag=0} 1' Cargo.toml > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
+          fi
+
+          echo "Updated workspace version to: ${{ env.VERSION }}"
+          echo "Workspace version: $(grep -A 10 '^\[workspace\.package\]' Cargo.toml | grep '^version' | cut -d'\"' -f2)"
+
+      - name: Validate crates before publishing
+        run: |
+          echo "Validating server crate..."
+          cargo check -p quetty-server
+
+          echo "Validating UI crate..."
+          cargo check -p quetty
+
+      - name: Dry run publish server crate
+        run: |
+          echo "Dry-run publishing server crate..."
+          cargo publish --dry-run -p quetty-server
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Publish server crate to crates.io
+        run: |
+          echo "Publishing server crate to crates.io..."
+          cargo publish -p quetty-server
+          echo "Server crate published successfully!"
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Wait for server crate to be available
+        run: |
+          echo "Waiting for server crate to become available on crates.io..."
+          sleep 30
+
+          # Poll crates.io API to ensure the crate is available
+          for i in {1..10}; do
+            if curl -f "https://crates.io/api/v1/crates/quetty-server/${{ env.VERSION }}" > /dev/null 2>&1; then
+              echo "Server crate is now available on crates.io!"
+              break
+            fi
+            echo "Attempt $i: Server crate not yet available, waiting..."
+            sleep 30
+          done
+
+      - name: Update UI crate dependency to use published version
+        run: |
+          echo "Updating UI crate to use published server crate..."
+          # Replace path dependency with published version
+          sed -i 's|quetty_server = { path = "../server", package = "quetty-server", version = ".*" }|quetty_server = { package = "quetty-server", version = "${{ env.VERSION }}" }|' ui/Cargo.toml
+
+          echo "Updated UI Cargo.toml:"
+          grep "quetty_server" ui/Cargo.toml
+
+      - name: Dry run publish UI crate
+        run: |
+          echo "Dry-run publishing UI crate..."
+          cargo check -p quetty
+          cargo publish --dry-run -p quetty
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Publish UI crate to crates.io
+        run: |
+          echo "Publishing UI crate to crates.io..."
+          cargo publish -p quetty
+          echo "UI crate published successfully!"
+          echo ""
+          echo "🎉 Both crates published to crates.io!"
+          echo "Install with: cargo install quetty"
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  create-release:
+    needs: [build, publish-to-crates-io]
     runs-on: ubuntu-latest
     if: github.ref_type == 'tag'
 
@@ -263,7 +374,16 @@ jobs:
           echo "" >> RELEASE_CHANGELOG.md
           echo "## Installation" >> RELEASE_CHANGELOG.md
           echo "" >> RELEASE_CHANGELOG.md
-          echo "Download the appropriate binary for your platform:" >> RELEASE_CHANGELOG.md
+          echo "### Using Cargo (Recommended)" >> RELEASE_CHANGELOG.md
+          echo "" >> RELEASE_CHANGELOG.md
+          echo "Install directly from crates.io:" >> RELEASE_CHANGELOG.md
+          echo "\`\`\`bash" >> RELEASE_CHANGELOG.md
+          echo "cargo install quetty" >> RELEASE_CHANGELOG.md
+          echo "\`\`\`" >> RELEASE_CHANGELOG.md
+          echo "" >> RELEASE_CHANGELOG.md
+          echo "### Binary Downloads" >> RELEASE_CHANGELOG.md
+          echo "" >> RELEASE_CHANGELOG.md
+          echo "Alternatively, download the appropriate binary for your platform:" >> RELEASE_CHANGELOG.md
           echo "" >> RELEASE_CHANGELOG.md
           echo "### Linux x64" >> RELEASE_CHANGELOG.md
           echo "\`\`\`bash" >> RELEASE_CHANGELOG.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -249,8 +249,8 @@ jobs:
       - name: Update UI crate dependency to use published version
         run: |
           echo "Updating UI crate to use published server crate..."
-          # Replace path dependency with published version
-          sed -i 's|quetty_server = { path = "../server", package = "quetty-server", version = ".*" }|quetty_server = { package = "quetty-server", version = "${{ env.VERSION }}" }|' ui/Cargo.toml
+          # Replace path dependency with published version (robust pattern)
+          sed -Ei 's#^quetty_server[[:space:]]*=.*#quetty_server = { package = "quetty-server", version = "${{ env.VERSION }}" }#' ui/Cargo.toml
 
           echo "Updated UI Cargo.toml:"
           grep "quetty_server" ui/Cargo.toml

--- a/docs/CRATES_IO_AUTOMATION.md
+++ b/docs/CRATES_IO_AUTOMATION.md
@@ -1,0 +1,126 @@
+# Crates.io Publishing Automation
+
+This document describes the automated crates.io publishing setup for Quetty.
+
+## Overview
+
+Quetty has automated publishing to crates.io that triggers on **stable releases only**. The automation publishes two crates:
+
+1. **`quetty-server`** - Core Azure Service Bus client library
+2. **`quetty`** - Main terminal application (installable binary)
+
+## How It Works
+
+### Automatic Publishing (GitHub Actions)
+
+The automation runs when you create a GitHub release with a stable version tag (no `-alpha`, `-beta`, or `-rc` suffixes).
+
+**Trigger:** Push tags matching `v*.*.*` (stable versions only)
+**Workflow:** `.github/workflows/release.yml`
+
+**Process:**
+1. **Validate release** - Ensures tag format and stable version
+2. **Build artifacts** - Creates binaries for all platforms
+3. **Publish server crate** - Publishes `quetty-server` to crates.io
+4. **Wait for availability** - Polls crates.io until server crate is available
+5. **Update UI dependencies** - Replaces path dependency with published version
+6. **Publish UI crate** - Publishes `quetty` (main installable package)
+7. **Create GitHub release** - Uploads artifacts and generates changelog
+
+### Manual Testing
+
+Use the helper script to test publishing locally:
+
+```bash
+# Dry-run test (recommended)
+./scripts/prepare_crates_release.sh 1.0.0 true
+
+# Actual publishing (requires CARGO_REGISTRY_TOKEN)
+export CARGO_REGISTRY_TOKEN=your_token_here
+./scripts/prepare_crates_release.sh 1.0.0
+```
+
+## Release Process
+
+### For Stable Releases
+
+1. **Prepare release:**
+   ```bash
+   ./scripts/release.sh 1.0.0
+   ```
+
+2. **Push to trigger automation:**
+   ```bash
+   git push origin main v1.0.0
+   ```
+
+3. **Monitor automation:**
+   - Check GitHub Actions: https://github.com/dawidpereira/quetty/actions
+   - Verify crates.io: https://crates.io/crates/quetty
+
+### For Pre-releases
+
+Pre-releases (versions with `-alpha`, `-beta`, `-rc`) will:
+- ✅ Build release artifacts
+- ✅ Create GitHub release
+- ❌ **NOT** publish to crates.io
+
+## Installation After Publishing
+
+Once published, users can install via:
+
+```bash
+cargo install quetty
+```
+
+## Required Secrets
+
+The GitHub repository requires this secret for automation:
+
+- **`CARGO_REGISTRY_TOKEN`** - Crates.io API token with publishing permissions
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Publishing fails for UI crate**
+   - Usually means server crate isn't available yet
+   - Automation waits up to 5 minutes for availability
+
+2. **Version already exists**
+   - Crates.io doesn't allow republishing same version
+   - Use a new version number
+
+3. **Metadata validation fails**
+   - Check that all required fields are present in Cargo.toml
+   - Validate with: `cargo publish --dry-run -p quetty-server`
+
+### Manual Recovery
+
+If automation fails, you can manually publish:
+
+```bash
+# Set token
+export CARGO_REGISTRY_TOKEN=your_token
+
+# Publish server crate first
+cargo publish -p quetty-server
+
+# Wait for availability, then update UI dependency and publish
+./scripts/prepare_crates_release.sh 1.0.0
+```
+
+## Crate Information
+
+### quetty-server
+- **Purpose:** Core Azure Service Bus client library
+- **Type:** Library crate
+- **Dependencies:** Azure SDK, async runtime, crypto libraries
+
+### quetty
+- **Purpose:** Terminal application (main package)
+- **Type:** Binary crate with library
+- **Binary name:** `quetty`
+- **Dependencies:** TUI libraries, quetty-server
+
+Both crates share workspace metadata and are versioned together.

--- a/scripts/prepare_crates_release.sh
+++ b/scripts/prepare_crates_release.sh
@@ -1,0 +1,162 @@
+#!/bin/bash
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+VERSION=$1
+DRY_RUN=${2:-false}
+
+if [ -z "$VERSION" ]; then
+  echo -e "${RED}❌ Usage: ./scripts/prepare_crates_release.sh <version> [dry-run]${NC}"
+  echo -e "${BLUE}Examples:${NC}"
+  echo "  ./scripts/prepare_crates_release.sh 1.2.0"
+  echo "  ./scripts/prepare_crates_release.sh 1.2.0 true  # dry-run mode"
+  echo ""
+  echo -e "${BLUE}💡 Note:${NC} This script prepares crates for publishing to crates.io"
+  exit 1
+fi
+
+# Validate version format
+if ! [[ $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
+  echo -e "${RED}❌ Invalid version format${NC}"
+  echo -e "${BLUE}Use semantic versioning:${NC} 1.2.0 or 1.2.0-beta.1"
+  exit 1
+fi
+
+echo -e "${BLUE}🚀 Preparing crates for release version ${YELLOW}$VERSION${NC}"
+if [ "$DRY_RUN" = "true" ]; then
+  echo -e "${YELLOW}🧪 Running in dry-run mode${NC}"
+fi
+
+# Check if we're in the right directory
+if [ ! -f "Cargo.toml" ] || [ ! -d "server" ] || [ ! -d "ui" ]; then
+  echo -e "${RED}❌ Must be run from the project root directory${NC}"
+  exit 1
+fi
+
+# Check for CARGO_REGISTRY_TOKEN if not in dry-run mode
+if [ "$DRY_RUN" != "true" ]; then
+  if [ -z "${CARGO_REGISTRY_TOKEN:-}" ]; then
+    echo -e "${RED}❌ CARGO_REGISTRY_TOKEN environment variable is required for publishing${NC}"
+    echo -e "${BLUE}Set it with:${NC} export CARGO_REGISTRY_TOKEN=your_token_here"
+    exit 1
+  fi
+fi
+
+# Update version in workspace Cargo.toml
+echo -e "${BLUE}📝 Updating workspace version to $VERSION...${NC}"
+
+# Check if cargo-edit is available for portable version management
+if command -v cargo-set-version >/dev/null 2>&1; then
+  echo -e "${BLUE}Using cargo set-version for cross-platform compatibility${NC}"
+  cargo set-version --workspace "$VERSION"
+else
+  echo -e "${YELLOW}cargo-edit not found, using awk (less portable)${NC}"
+  # Use awk to update the workspace version in root Cargo.toml
+  tmp=$(mktemp)
+  awk -v version="$VERSION" '/^\[workspace\.package\]/{flag=1; print; next} flag && /^version = /{sub(/version = ".*"/, "version = \"" version "\""); flag=0} 1' Cargo.toml > "$tmp" && mv "$tmp" Cargo.toml
+fi
+
+# Verify changes
+echo -e "${BLUE}🔍 Verifying version updates...${NC}"
+WORKSPACE_VERSION=$(grep -A 10 "^\[workspace\.package\]" Cargo.toml | grep "^version" | cut -d'"' -f2)
+
+if [ "$WORKSPACE_VERSION" != "$VERSION" ]; then
+  echo -e "${RED}❌ Version update failed${NC}"
+  echo "Expected: $VERSION"
+  echo "Workspace: $WORKSPACE_VERSION"
+  exit 1
+fi
+
+echo -e "${GREEN}✅ Updated workspace version:${NC}"
+echo "  Cargo.toml: $WORKSPACE_VERSION"
+
+# Validate crates
+echo -e "${BLUE}🔍 Validating crates...${NC}"
+cargo check -p quetty-server
+cargo check -p quetty
+
+# Dry run publish for both crates
+echo -e "${BLUE}🧪 Testing crate publishing (dry-run)...${NC}"
+
+echo -e "${BLUE}Testing server crate...${NC}"
+cargo publish --dry-run -p quetty-server
+
+echo -e "${BLUE}Testing UI crate...${NC}"
+cargo publish --dry-run -p quetty
+
+if [ "$DRY_RUN" = "true" ]; then
+  echo -e "${GREEN}✅ Dry-run completed successfully!${NC}"
+  echo -e "${BLUE}All crates are ready for publishing to crates.io${NC}"
+  exit 0
+fi
+
+# Actual publishing
+echo -e "${BLUE}📦 Publishing to crates.io...${NC}"
+
+# Publish server crate first
+echo -e "${BLUE}Publishing server crate...${NC}"
+cargo publish -p quetty-server
+echo -e "${GREEN}✅ Server crate published successfully!${NC}"
+
+# Wait for server crate to be available
+echo -e "${BLUE}⏳ Waiting for server crate to become available on crates.io...${NC}"
+sleep 30
+
+# Poll crates.io API to ensure the crate is available
+for i in {1..10}; do
+  if curl -f "https://crates.io/api/v1/crates/quetty-server/$VERSION" > /dev/null 2>&1; then
+    echo -e "${GREEN}✅ Server crate is now available on crates.io!${NC}"
+    break
+  fi
+  echo -e "${YELLOW}Attempt $i: Server crate not yet available, waiting...${NC}"
+  sleep 30
+done
+
+# Update UI crate dependency to use published version
+echo -e "${BLUE}📝 Updating UI crate to use published server crate...${NC}"
+# Create backup
+cp ui/Cargo.toml ui/Cargo.toml.bak
+
+# Replace path dependency with published version
+sed -i.tmp 's|quetty_server = { path = "../server", package = "quetty-server", version = ".*" }|quetty_server = { package = "quetty-server", version = "'$VERSION'" }|' ui/Cargo.toml
+
+echo -e "${BLUE}Updated UI Cargo.toml dependency:${NC}"
+grep "quetty_server" ui/Cargo.toml
+
+# Validate UI crate with new dependency
+echo -e "${BLUE}🔍 Validating UI crate with published dependency...${NC}"
+cargo check -p quetty
+
+# Dry run publish UI crate
+echo -e "${BLUE}Testing UI crate publishing...${NC}"
+cargo publish --dry-run -p quetty
+
+# Publish UI crate
+echo -e "${BLUE}Publishing UI crate...${NC}"
+cargo publish -p quetty
+echo -e "${GREEN}✅ UI crate published successfully!${NC}"
+
+# Restore original Cargo.toml for development
+echo -e "${BLUE}🔄 Restoring original UI Cargo.toml for development...${NC}"
+mv ui/Cargo.toml.bak ui/Cargo.toml
+
+echo ""
+echo -e "${GREEN}🎉 Both crates published to crates.io successfully!${NC}"
+echo ""
+echo -e "${BLUE}📦 Installation:${NC}"
+echo "  cargo install quetty"
+echo ""
+echo -e "${BLUE}🔗 Crates.io links:${NC}"
+echo "  Server: https://crates.io/crates/quetty-server"
+echo "  UI: https://crates.io/crates/quetty"
+echo ""
+echo -e "${BLUE}💡 Next steps:${NC}"
+echo "  1. Test installation: cargo install quetty"
+echo "  2. Create GitHub release with: git push origin v$VERSION"
+echo "  3. Monitor release build at: https://github.com/dawidpereira/quetty/actions"

--- a/scripts/prepare_crates_release.sh
+++ b/scripts/prepare_crates_release.sh
@@ -123,8 +123,11 @@ echo -e "${BLUE}📝 Updating UI crate to use published server crate...${NC}"
 # Create backup
 cp ui/Cargo.toml ui/Cargo.toml.bak
 
-# Replace path dependency with published version
-sed -i.tmp 's|quetty_server = { path = "../server", package = "quetty-server", version = ".*" }|quetty_server = { package = "quetty-server", version = "'$VERSION'" }|' ui/Cargo.toml
+# Replace path dependency with published version (robust, no tmp artifacts)
+sed -Ei 's#^quetty_server[[:space:]]*=.*#quetty_server = { package = "quetty-server", version = "'"$VERSION"'" }#' ui/Cargo.toml
+
+# Clean up any possible tmp files from previous runs
+rm -f ui/Cargo.toml.tmp
 
 echo -e "${BLUE}Updated UI Cargo.toml dependency:${NC}"
 grep "quetty_server" ui/Cargo.toml

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -66,9 +66,9 @@ else
   echo -e "${YELLOW}cargo-edit not found, using sed (less portable)${NC}"
   # Fallback to awk for better cross-platform compatibility
   tmp=$(mktemp)
-  awk -v version="$VERSION" 'NR==3{sub(/^version = ".*"/, "version = \"" version "\"")} 1' ui/Cargo.toml > "$tmp" && mv "$tmp" ui/Cargo.toml
+  awk -v version="$VERSION" 'NR==3{sub(/^version = ".*"/, "version = \"" version "\"")} 1' ui/Cargo.toml >"$tmp" && mv "$tmp" ui/Cargo.toml
   tmp=$(mktemp)
-  awk -v version="$VERSION" 'NR==3{sub(/^version = ".*"/, "version = \"" version "\"")} 1' server/Cargo.toml > "$tmp" && mv "$tmp" server/Cargo.toml
+  awk -v version="$VERSION" 'NR==3{sub(/^version = ".*"/, "version = \"" version "\"")} 1' server/Cargo.toml >"$tmp" && mv "$tmp" server/Cargo.toml
 fi
 
 # Verify changes
@@ -122,8 +122,14 @@ echo "  git push origin main v$VERSION"
 echo ""
 echo -e "${BLUE}After pushing:${NC}"
 echo "  • GitHub Actions will build release artifacts"
+echo "  • Crates will be automatically published to crates.io (stable releases only)"
 echo "  • Check the release at: https://github.com/dawidpereira/quetty/releases"
 echo "  • Monitor the build: https://github.com/dawidpereira/quetty/actions"
+echo ""
+echo -e "${BLUE}📦 Crates.io Publishing:${NC}"
+echo "  • Stable releases (no -alpha, -beta, -rc) will be auto-published"
+echo "  • Pre-releases will only build artifacts (no crates.io publishing)"
+echo "  • To manually test crates publishing: ./scripts/prepare_crates_release.sh $VERSION true"
 echo ""
 echo -e "${BLUE}To create the next development version:${NC}"
 echo "  git checkout main"


### PR DESCRIPTION
- Add crates.io publishing job to GitHub Actions release workflow
- Publish quetty-server library crate first, then quetty binary crate
- Only publish stable releases (exclude alpha/beta/rc versions)
- Add helper script for local testing and manual publishing
- Update release notes to include cargo install instructions
- Handle workspace version management correctly
- Add comprehensive automation documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced automated publishing of Rust crates to crates.io for stable releases, including sequential publishing of server and UI crates with dependency updates and validation.
  * Added a script to automate crate preparation and publishing, supporting both dry-run and actual publish modes.

* **Documentation**
  * Added detailed documentation describing the automated crates.io publishing process, manual testing steps, troubleshooting, and installation instructions.
  * Enhanced release process documentation with clear instructions on publishing behavior for stable and pre-release versions.

* **Chores**
  * Improved version update logic to target the workspace Cargo.toml for consistency across crates.
  * Clarified release workflow logs and changelog generation, now promoting installation via Cargo.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->