### PR TITLE
fix: correct Service Bus link credit validation for all message posit…

### DIFF
--- a/ui/src/app/queue_state.rs
+++ b/ui/src/app/queue_state.rs
@@ -82,8 +82,8 @@ impl BulkSelectionState {
         self.selected_messages.iter().cloned().collect()
     }
 
-    /// Get the highest selected index for max_position calculation
-    pub fn get_highest_selected_index(&self) -> Option<usize> {
+    /// Get the highest selected position (1-based) for max_position calculation
+    pub fn get_highest_selected_position(&self) -> Option<usize> {
         self.selected_indices.iter().max().map(|&index| index + 1)
     }
 

--- a/ui/src/app/updates/messages/bulk_execution/operation_setup.rs
+++ b/ui/src/app/updates/messages/bulk_execution/operation_setup.rs
@@ -379,9 +379,9 @@ impl<T: TerminalAdapter> ValidatedBulkOperation<T> {
         let max_position = if let Some(highest_index) = model
             .queue_state()
             .bulk_selection
-            .get_highest_selected_index()
+            .get_highest_selected_position()
         {
-            // get_highest_selected_index now returns 1-based position
+            // get_highest_selected_position returns 1-based position
             highest_index
         } else if self.message_ids.len() == 1 {
             // Single message operation - calculate global index properly

--- a/ui/src/app/updates/messages/bulk_execution/send_operations.rs
+++ b/ui/src/app/updates/messages/bulk_execution/send_operations.rs
@@ -491,7 +491,7 @@ fn start_bulk_send_operation<T: TerminalAdapter>(
     let max_position = if let Some(highest_index) = model
         .queue_state()
         .bulk_selection
-        .get_highest_selected_index()
+        .get_highest_selected_position()
     {
         highest_index
     } else if message_ids.len() == 1 {
@@ -534,9 +534,8 @@ fn start_bulk_send_with_data_operation<T: TerminalAdapter>(
     let max_position = if let Some(highest_index) = model
         .queue_state()
         .bulk_selection
-        .get_highest_selected_index()
+        .get_highest_selected_position()
     {
-        // get_highest_selected_index now returns 1-based position
         highest_index
     } else if messages_data.len() == 1 {
         // Single message operation - get current message index from UI state


### PR DESCRIPTION
…ions

The previous implementation had two critical issues:
1. For single message operations, it used the local UI index (0-based on current page)
   instead of the global position, allowing operations beyond position 2048
2. For bulk selections, it incorrectly calculated gaps by subtracting count from max
   position rather than summing actual intervals between selections

Now properly validates:
- Single messages: Checks if global position exceeds 2048 limit
- Multiple selections: Calculates sum of gaps between selected messages
- Both scenarios provide clear error messages with actionable solutions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to calculate the number of gaps between selected messages, providing clearer insight into selection continuity.
* **Improvements**
  * Enhanced accuracy in determining the highest selected message and global message positions, especially for single-message operations.
  * Improved validation and feedback when performing bulk actions that approach or exceed Azure Service Bus link credit limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->